### PR TITLE
Accept encrypted passwords for user add & modify

### DIFF
--- a/.cyclid.json
+++ b/.cyclid.json
@@ -12,11 +12,11 @@
    "sources": [
       {
         "type": "git",
-        "url": "https://github.com/Liqwyd/Cyclid-core"
+        "url": "https://github.com/Cyclid/Cyclid-core"
       },
       {
         "type": "git",
-        "url": "https://github.com/Liqwyd/Cyclid-client"
+        "url": "https://github.com/Cyclid/Cyclid-client"
       }
    ],
    "stages" : [

--- a/lib/cyclid/client/user.rb
+++ b/lib/cyclid/client/user.rb
@@ -49,7 +49,8 @@ module Cyclid
       # @param username [String] User name of the new user.
       # @param name [String] Users real name.
       # @param email [String] Users email address.
-      # @param password [String] Unencrypted initial password
+      # @param password [String] Unencrypted initial password OR a BCrypt2
+      #   encrypted password string.
       # @param secret [String] Initial HMAC signing secret
       # @return [Hash] Decoded server response object.
       # @see #user_modify
@@ -64,8 +65,14 @@ module Cyclid
         # Add the HMAC secret if one was supplied
         user['secret'] = secret unless secret.nil?
 
-        # Encrypt & add the password if one was supplied
-        user['password'] = BCrypt::Password.create(password).to_s unless password.nil?
+        # Add the password if one was supplied
+        if password =~ /\A\$2a\$.+\z/
+          # Password is already encrypted
+          user['password'] = password
+        else
+          # Encrypt the plaintext password
+          user['password'] = BCrypt::Password.create(password).to_s
+        end unless password.nil?
 
         @logger.debug user
 
@@ -84,6 +91,8 @@ module Cyclid
       # @option args [String] email Users email address.
       # @option args [String] secret Initial HMAC signing secret
       # @option args [String] password Unencrypted initial password
+      # @option args [String] password Unencrypted initial password OR a
+      #   BCrypt2 encrypted password string.
       # @return [Hash] Decoded server response object.
       # @see #user_add
       # @see #user_delete
@@ -104,9 +113,14 @@ module Cyclid
         # Add the HMAC secret if one was supplied
         user['secret'] = args[:secret] if args.key? :secret and args[:secret]
 
-        # Encrypt & add the password if one was supplied
-        user['password'] = BCrypt::Password.create(args[:password]).to_s \
-          if args.key? :password and args[:password]
+        # Add the password if one was supplied
+        if args[:password] =~ /\A\$2a\$.+\z/
+          # Password is already encrypted
+          user['password'] = args[:password]
+        else
+          # Encrypt the plaintext password
+          user['password'] = BCrypt::Password.create(args[:password]).to_s
+        end if args.key? :password and args[:password]
 
         @logger.debug user
 

--- a/lib/cyclid/client/user.rb
+++ b/lib/cyclid/client/user.rb
@@ -66,13 +66,13 @@ module Cyclid
         user['secret'] = secret unless secret.nil?
 
         # Add the password if one was supplied
-        if password =~ /\A\$2a\$.+\z/
-          # Password is already encrypted
-          user['password'] = password
-        else
-          # Encrypt the plaintext password
-          user['password'] = BCrypt::Password.create(password).to_s
-        end unless password.nil?
+        user['password'] = if password =~ /\A\$2a\$.+\z/
+                             # Password is already encrypted
+                             password
+                           else
+                             # Encrypt the plaintext password
+                             BCrypt::Password.create(password).to_s
+                           end unless password.nil?
 
         @logger.debug user
 
@@ -114,13 +114,13 @@ module Cyclid
         user['secret'] = args[:secret] if args.key? :secret and args[:secret]
 
         # Add the password if one was supplied
-        if args[:password] =~ /\A\$2a\$.+\z/
-          # Password is already encrypted
-          user['password'] = args[:password]
-        else
-          # Encrypt the plaintext password
-          user['password'] = BCrypt::Password.create(args[:password]).to_s
-        end if args.key? :password and args[:password]
+        user['password'] = if args[:password] =~ /\A\$2a\$.+\z/
+                             # Password is already encrypted
+                             args[:password]
+                           else
+                             # Encrypt the plaintext password
+                             BCrypt::Password.create(args[:password]).to_s
+                           end if args.key? :password and args[:password]
 
         @logger.debug user
 

--- a/spec/client/user_spec.rb
+++ b/spec/client/user_spec.rb
@@ -98,6 +98,23 @@ describe Cyclid::Client::User do
       expect{ res = @client.user_add('bob', 'bob@example.com', nil, 'm1lkb0ne') }.to_not raise_error
       expect(res['test']).to eq('data')
     end
+
+    it 'creates a new user with a previously encrypted password specified' do
+      stub_request(:post, 'http://localhost:9999/users')
+        .with(body: /{"username":"bob","email":"bob@example.com","password":"\$2a\$10\$42uBIU4TTVTWAYs2rUN\.dO9HumdFHxsLa3qqQ2U0SvNZFMuljNhQO"}/,
+              headers: { 'Accept' => '*/*',
+                         'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                         'Authorization' => /\AHMAC admin:.*\z/,
+                         'Host' => 'localhost:9999',
+                         'User-Agent' => 'Ruby',
+                         'Date' => /.*/,
+                         'X-Hmac-Nonce' => /.*/ })
+        .to_return(status: 200, body: '{"test": "data"}', headers: {})
+
+      res = {}
+      expect{ res = @client.user_add('bob', 'bob@example.com', nil, '$2a$10$42uBIU4TTVTWAYs2rUN.dO9HumdFHxsLa3qqQ2U0SvNZFMuljNhQO') }.to_not raise_error
+      expect(res['test']).to eq('data')
+    end
   end
 
   context 'modifying users' do
@@ -156,6 +173,25 @@ describe Cyclid::Client::User do
         .to_return(status: 200, body: '{"test": "data"}', headers: {})
 
       new_user = { password: 'm1lkb0ne' }
+
+      res = {}
+      expect{ res = @client.user_modify('bob', new_user) }.to_not raise_error
+      expect(res['test']).to eq('data')
+    end
+
+    it 'changes the users password with a previously encrypted password' do
+      stub_request(:put, 'http://localhost:9999/users/bob')
+        .with(body: /{"password":"\$2a\$10\$42uBIU4TTVTWAYs2rUN\.dO9HumdFHxsLa3qqQ2U0SvNZFMuljNhQO"}/,
+              headers: { 'Accept' => '*/*',
+                         'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                         'Authorization' => /\AHMAC admin:.*\z/,
+                         'Host' => 'localhost:9999',
+                         'User-Agent' => 'Ruby',
+                         'Date' => /.*/,
+                         'X-Hmac-Nonce' => /.*/ })
+        .to_return(status: 200, body: '{"test": "data"}', headers: {})
+
+      new_user = { password: '$2a$10$42uBIU4TTVTWAYs2rUN.dO9HumdFHxsLa3qqQ2U0SvNZFMuljNhQO' }
 
       res = {}
       expect{ res = @client.user_modify('bob', new_user) }.to_not raise_error


### PR DESCRIPTION
There may be occassions when the password has already been encrypted, and the
client API should support passing an encrypted password instead of a plaintext
string which it then encrypts itself.