### PR TITLE
Improve TLS support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: ../Cyclid-core/
+  remote: ../Cyclid-core
   specs:
     cyclid-core (0.1.1)
       rack (~> 1.6)
@@ -86,4 +86,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.11.2
+   1.14.3

--- a/lib/cyclid/cli/organization.rb
+++ b/lib/cyclid/cli/organization.rb
@@ -71,8 +71,9 @@ module Cyclid
             config = Cyclid::Client::Config.new(path: fname)
 
             puts File.basename(fname).colorize(:cyan)
-            uri = URI::HTTP.build(host: config.server, port: config.port)
-            puts "\tServer: ".colorize(:cyan) + uri.to_s
+            scheme = config.tls ? URI::HTTPS : URI::HTTP
+            uri = scheme.build(host: config.server, port: config.port)
+            puts "\tURL: ".colorize(:cyan) + uri.to_s
             puts "\tOrganization: ".colorize(:cyan) + config.organization
             puts "\tUsername: ".colorize(:cyan) + config.username
           rescue StandardError => ex

--- a/lib/cyclid/client.rb
+++ b/lib/cyclid/client.rb
@@ -84,9 +84,10 @@ module Cyclid
 
       # Build a URI for the configured server & required resource
       def server_uri(path)
-        URI::HTTP.build(host: @config.server,
-                        port: @config.port,
-                        path: path)
+        scheme = @config.tls ? URI::HTTPS : URI::HTTP
+        scheme.build(host: @config.server,
+                     port: @config.port,
+                     path: path)
       end
 
       def method_missing(method, *args, &block) # rubocop:disable Style/MethodMissing

--- a/lib/cyclid/client/api.rb
+++ b/lib/cyclid/client/api.rb
@@ -79,6 +79,8 @@ module Cyclid
         # Perform an API HTTP request & return the parsed response body
         def api_request(uri, req)
           http = Net::HTTP.new(uri.hostname, uri.port)
+          http.use_ssl = uri.scheme == 'https'
+
           res = http.request(req)
 
           parse_response(res)

--- a/lib/cyclid/config.rb
+++ b/lib/cyclid/config.rb
@@ -14,13 +14,23 @@
 # limitations under the License.
 
 require 'yaml'
+require 'uri'
 require 'cyclid/auth_methods'
 
 module Cyclid
   module Client
     # Cyclid client per-organization configuration
     class Config
-      attr_reader :auth, :server, :port, :organization, :username, :secret, :password, :token, :path
+      attr_reader :auth,
+                  :server,
+                  :port,
+                  :tls,
+                  :organization,
+                  :username,
+                  :secret,
+                  :password,
+                  :token,
+                  :path
       # @!attribute [r] auth
       #   @return [Fixnum] the authentication method. (Default is AUTH_HMAC)
       # @!attribute [r] server
@@ -73,13 +83,23 @@ module Cyclid
         # Set defaults from the options
         @server = options[:server] || nil
         @port = options[:port] || nil
+        @tls = options[:tls] || nil
         @organization = options[:organization] || nil
         @username = options[:username] || nil
 
         # Get anything provided in the config file
         if @config
-          @server ||= @config['server']
-          @port ||= @config['port'] || 8361
+          if @config.key? 'url'
+            uri = URI.parse(@config['url'])
+
+            @server ||= uri.host
+            @port ||= uri.port
+            @tls ||= uri.scheme == 'https' ? true : false
+          else
+            @server ||= @config['server']
+            @port ||= @config['port'] || 8361
+            @tls ||= @config['tls'] || false
+          end
           @organization ||= @config['organization']
           @username ||= @config['username']
         end

--- a/spec/cli/organization_spec.rb
+++ b/spec/cli/organization_spec.rb
@@ -119,7 +119,7 @@ describe Cyclid::Cli::Organization do
 
         expect{ subject.list }.to_not raise_error
         expect{ subject.list }.to output(/.*(org1|org2)/).to_stdout
-        expect{ subject.list }.to output(/.*Server:.*localhost/).to_stdout
+        expect{ subject.list }.to output(/.*URL:.*localhost/).to_stdout
         expect{ subject.list }.to output(/.*Organization:.*admins/).to_stdout
         expect{ subject.list }.to output(/.*Username:.*admin/).to_stdout
       end


### PR DESCRIPTION
Allow the server URL to be specified as a single url in the config file and parse out the scheme, server & port from it if it's there.
Add the tls option to the config file.
If tls is enabled ("tls: true" or the scheme is "https") always enable TLS during API operations.
Make sure "org list" always displays the correct URL including scheme, and rename "Server" to "URL"