### PR TITLE
Add Job list & stat commands

### DIFF
--- a/lib/cyclid/cli/admin.rb
+++ b/lib/cyclid/cli/admin.rb
@@ -28,6 +28,9 @@ module Cyclid
       desc 'organization', 'Manage organizations'
       subcommand 'organization', AdminOrganization
       map 'org' => :organization
+
+      desc 'job', 'Manage jobs'
+      subcommand 'job', AdminJob
     end
   end
 end

--- a/lib/cyclid/cli/admin/job.rb
+++ b/lib/cyclid/cli/admin/job.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+# Copyright 2016 Liqwyd Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Cyclid
+  module Cli
+    # 'admin job' sub-commands
+    class AdminJob < Thor
+      desc 'list NAME', 'List all jobs for the organization NAME'
+      def list(name)
+        stats = client.job_stats(name)
+        all = client.job_list(name, limit: stats['total'])
+        jobs = all['records']
+
+        jobs.each do |job|
+          puts 'Name: '.colorize(:cyan) + (job['job_name'] || '')
+          puts "\tJob: ".colorize(:cyan) + job['id'].to_s
+          puts "\tVersion: ".colorize(:cyan) + (job['job_version'] || '')
+        end
+      rescue StandardError => ex
+        STDERR.puts ex.backtrace
+        abort "Failed to get job list: #{ex}"
+      end
+
+      desc 'stats NAME', 'Show statistics about jobs for the organization NAME'
+      def stats(name)
+        stats = client.job_stats(name)
+
+        puts 'Total jobs: '.colorize(:cyan) + stats['total'].to_s
+      rescue StandardError => ex
+        abort "Failed to get job list: #{ex}"
+      end
+    end
+  end
+end

--- a/lib/cyclid/cli/job.rb
+++ b/lib/cyclid/cli/job.rb
@@ -114,6 +114,30 @@ module Cyclid
       rescue StandardError => ex
         abort "Failed to get job log: #{ex}"
       end
+
+      desc 'list', 'List all jobs'
+      def list
+        stats = client.job_stats(client.config.organization)
+        all = client.job_list(client.config.organization, limit: stats['total'])
+        jobs = all['records']
+
+        jobs.each do |job|
+          puts 'Name: '.colorize(:cyan) + (job['job_name'] || '')
+          puts "\tJob: ".colorize(:cyan) + job['id'].to_s
+          puts "\tVersion: ".colorize(:cyan) + (job['job_version'] || '')
+        end
+      rescue StandardError => ex
+        abort "Failed to get job list: #{ex}"
+      end
+
+      desc 'stats', 'Show statistics about jobs'
+      def stats
+        stats = client.job_stats(client.config.organization)
+
+        puts 'Total jobs: '.colorize(:cyan) + stats['total'].to_s
+      rescue StandardError => ex
+        abort "Failed to get job list: #{ex}"
+      end
     end
   end
 end

--- a/lib/cyclid/client.rb
+++ b/lib/cyclid/client.rb
@@ -83,11 +83,12 @@ module Cyclid
       private
 
       # Build a URI for the configured server & required resource
-      def server_uri(path)
+      def server_uri(path, query = nil)
         scheme = @config.tls ? URI::HTTPS : URI::HTTP
         scheme.build(host: @config.server,
                      port: @config.port,
-                     path: path)
+                     path: path,
+                     query: query)
       end
 
       def method_missing(method, *args, &block) # rubocop:disable Style/MethodMissing

--- a/lib/cyclid/client/job.rb
+++ b/lib/cyclid/client/job.rb
@@ -84,6 +84,25 @@ module Cyclid
 
         return res_data
       end
+
+      def job_stats(organization)
+        uri = server_uri("/organizations/#{organization}/jobs", 'stats_only=true')
+        res_data = api_get(uri)
+        @logger.debug res_data
+
+        return res_data
+      end
+
+      def job_list(organization, args = {})
+        # Convert the args hash into a query string
+        query = args.map { |k, v| "#{k}=#{v}" }.join('&')
+
+        uri = server_uri("/organizations/#{organization}/jobs", query)
+        res_data = api_get(uri)
+        @logger.debug res_data
+
+        return res_data
+      end
     end
   end
 end


### PR DESCRIPTION
Add "job list" and "job stats" commands to the CLI.
Add "admin job" subcommand, and "admin job list" & "admin job stats" commands
to the CLI.
Add job_stats & job_list methods to Tillapia.
Allow server_uri to take an optional query string & add it to the URI, which
is required for things like collecting the job statistics from the API
(?stats_only=true)