### PR TITLE
Big bug squash

### DIFF
--- a/lib/cyclid/cli/admin/job.rb
+++ b/lib/cyclid/cli/admin/job.rb
@@ -24,12 +24,11 @@ module Cyclid
         jobs = all['records']
 
         jobs.each do |job|
-          puts 'Name: '.colorize(:cyan) + (job['job_name'] || '')
-          puts "\tJob: ".colorize(:cyan) + job['id'].to_s
-          puts "\tVersion: ".colorize(:cyan) + (job['job_version'] || '')
+          Formatter.colorize 'Name', (job['job_name'] || '')
+          Formatter.colorize "\tJob", job['id'].to_s
+          Formatter.colorize "\tVersion", (job['job_version'] || '')
         end
       rescue StandardError => ex
-        STDERR.puts ex.backtrace
         abort "Failed to get job list: #{ex}"
       end
 
@@ -37,7 +36,7 @@ module Cyclid
       def stats(name)
         stats = client.job_stats(name)
 
-        puts 'Total jobs: '.colorize(:cyan) + stats['total'].to_s
+        Formatter.colorize 'Total jobs', stats['total'].to_s
       rescue StandardError => ex
         abort "Failed to get job list: #{ex}"
       end

--- a/lib/cyclid/cli/admin/organization.rb
+++ b/lib/cyclid/cli/admin/organization.rb
@@ -36,16 +36,16 @@ module Cyclid
         public_key = OpenSSL::PKey::RSA.new(der_key)
 
         # Pretty print the organization details
-        puts 'Name: '.colorize(:cyan) + org['name']
-        puts 'Owner Email: '.colorize(:cyan) + org['owner_email']
-        puts 'Public Key: '.colorize(:cyan) + public_key.to_pem
-        puts 'Members:'.colorize(:cyan)
+        Formatter.colorize 'Name', org['name']
+        Formatter.colorize 'Owner Email', org['owner_email']
+        Formatter.colorize 'Public Key', public_key.to_pem
+        Formatter.colorize 'Members:'
         if org['users'].any?
           org['users'].each do |user|
-            puts "\t#{user}"
+            Formatter.puts "\t#{user}"
           end
         else
-          puts "\tNone"
+          Formatter.puts "\tNone"
         end
       rescue StandardError => ex
         abort "Failed to get organization: #{ex}"
@@ -107,7 +107,7 @@ module Cyclid
         if options[:force]
           delete = true
         else
-          print "Delete organization #{name}: are you sure? (Y/n): ".colorize(:red)
+          Formatter.ask "Delete organization #{name}: are you sure? (Y/n)"
           delete = STDIN.getc.chr.casecmp('y').zero?
         end
         abort unless delete

--- a/lib/cyclid/cli/admin/user.rb
+++ b/lib/cyclid/cli/admin/user.rb
@@ -32,16 +32,16 @@ module Cyclid
         user = client.user_get(username)
 
         # Pretty print the user details
-        puts 'Username: '.colorize(:cyan) + user['username']
-        puts 'Name: '.colorize(:cyan) + (user['name'] || '')
-        puts 'Email: '.colorize(:cyan) + user['email']
-        puts 'Organizations:'.colorize(:cyan)
+        Formatter.colorize 'Username', user['username']
+        Formatter.colorize 'Name', (user['name'] || '')
+        Formatter.colorize 'Email', user['email']
+        Formatter.colorize 'Organizations:'
         if user['organizations'].any?
           user['organizations'].each do |org|
-            puts "\t#{org}"
+            Formatter.puts "\t#{org}"
           end
         else
-          puts "\tNone"
+          Formatter.puts "\tNone"
         end
       rescue StandardError => ex
         abort "Failed to get user: #{ex}"
@@ -127,7 +127,7 @@ module Cyclid
         if options[:force]
           delete = true
         else
-          print "Delete user #{username}: are you sure? (Y/n): ".colorize(:red)
+          Formatter.ask "Delete user #{username}: are you sure? (Y/n)"
           delete = STDIN.getc.chr.casecmp('y').zero?
         end
         abort unless delete

--- a/lib/cyclid/cli/formatter.rb
+++ b/lib/cyclid/cli/formatter.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+# Copyright 2016 Liqwyd Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'colorize'
+
+module Cyclid
+  module Cli
+    # Output formatter
+    module Formatter
+      # Output with no additional formatting
+      class Base
+        class << self
+          def puts(title, *args)
+            t = if args.empty?
+                  title
+                else
+                  "#{title}: "
+                end
+            Kernel.puts t + args.join
+          end
+          alias colorize puts
+
+          def ask(question)
+            print "#{question}: "
+          end
+        end
+      end
+
+      # Output with XTerm compatible color
+      class Terminal < Base
+        class << self
+          def colorize(title, *args)
+            t = if args.empty?
+                  title
+                else
+                  "#{title}: "
+                end
+            Kernel.puts t.colorize(:cyan) + args.join
+          end
+
+          def ask(question)
+            print "#{question}: ".colorize(:red)
+          end
+        end
+      end
+
+      class << self
+        def method_missing(method, *args, &block) # rubocop:disable Style/MethodMissing
+          @formatter ||= get
+          @formatter.send(method, *args, &block)
+        end
+
+        private
+
+        def get
+          STDOUT.tty? ? Terminal : Base
+        end
+      end
+    end
+  end
+end

--- a/lib/cyclid/cli/job.rb
+++ b/lib/cyclid/cli/job.rb
@@ -63,7 +63,7 @@ module Cyclid
         end
 
         job_info = client.job_submit(client.config.organization, job, job_type)
-        puts 'Job: '.colorize(:cyan) + job_info['job_id'].to_s
+        Formatter.colorize 'Job', job_info['job_id'].to_s
       rescue StandardError => ex
         abort "Failed to submit job: #{ex}"
       end
@@ -82,13 +82,13 @@ module Cyclid
         duration = (Time.new(0) + (ended - started) if started && ended)
 
         # Pretty-print the job details (without the log)
-        puts 'Job: '.colorize(:cyan) + job['id'].to_s
-        puts 'Name: '.colorize(:cyan) + (job['job_name'] || '')
-        puts 'Version: '.colorize(:cyan) + (job['job_version'] || '')
-        puts 'Started: '.colorize(:cyan) + (started ? started.asctime : '')
-        puts 'Ended: '.colorize(:cyan) + (ended ? ended.asctime : '')
-        puts 'Duration: '.colorize(:cyan) + duration.strftime('%H:%M:%S') if duration
-        puts 'Status: '.colorize(:cyan) + status
+        Formatter.colorize 'Job', job['id'].to_s
+        Formatter.colorize 'Name', (job['job_name'] || '')
+        Formatter.colorize 'Version', (job['job_version'] || '')
+        Formatter.colorize 'Started', (started ? started.asctime : '')
+        Formatter.colorize 'Ended', (ended ? ended.asctime : '')
+        Formatter.colorize 'Duration', duration.strftime('%H:%M:%S') if duration
+        Formatter.colorize 'Status', status
       rescue StandardError => ex
         abort "Failed to get job status: #{ex}"
       end
@@ -101,7 +101,7 @@ module Cyclid
         status = Cyclid::API::Constants::JOB_STATUSES[status_id]
 
         # Pretty-print the job status
-        puts 'Status: '.colorize(:cyan) + status
+        Formatter.colorize 'Status', status
       rescue StandardError => ex
         abort "Failed to get job status: #{ex}"
       end
@@ -122,9 +122,9 @@ module Cyclid
         jobs = all['records']
 
         jobs.each do |job|
-          puts 'Name: '.colorize(:cyan) + (job['job_name'] || '')
-          puts "\tJob: ".colorize(:cyan) + job['id'].to_s
-          puts "\tVersion: ".colorize(:cyan) + (job['job_version'] || '')
+          Formatter.colorize 'Name', (job['job_name'] || '')
+          Formatter.colorize "\tJob", job['id'].to_s
+          Formatter.colorize "\tVersion", (job['job_version'] || '')
         end
       rescue StandardError => ex
         abort "Failed to get job list: #{ex}"
@@ -134,7 +134,7 @@ module Cyclid
       def stats
         stats = client.job_stats(client.config.organization)
 
-        puts 'Total jobs: '.colorize(:cyan) + stats['total'].to_s
+        Formatter.colorize 'Total jobs', stats['total'].to_s
       rescue StandardError => ex
         abort "Failed to get job list: #{ex}"
       end

--- a/lib/cyclid/cli/organization.rb
+++ b/lib/cyclid/cli/organization.rb
@@ -31,10 +31,10 @@ module Cyclid
         public_key = OpenSSL::PKey::RSA.new(der_key)
 
         # Pretty print the organization details
-        puts 'Name: '.colorize(:cyan) + org['name']
-        puts 'Owner Email: '.colorize(:cyan) + org['owner_email']
-        puts 'Public Key: '.colorize(:cyan) + public_key.to_pem
-        puts 'Members:'.colorize(:cyan)
+        Formatter.colorize 'Name', org['name']
+        Formatter.colorize 'Owner Email', org['owner_email']
+        Formatter.colorize 'Public Key', public_key.to_pem
+        Formatter.colorize 'Members'
         if org['users'].any?
           org['users'].each do |user|
             puts "\t#{user}"
@@ -70,12 +70,12 @@ module Cyclid
             # Create a Config from this file and display the details
             config = Cyclid::Client::Config.new(path: fname)
 
-            puts File.basename(fname).colorize(:cyan)
+            Formatter.colorize File.basename(fname)
             scheme = config.tls ? URI::HTTPS : URI::HTTP
             uri = scheme.build(host: config.server, port: config.port)
-            puts "\tURL: ".colorize(:cyan) + uri.to_s
-            puts "\tOrganization: ".colorize(:cyan) + config.organization
-            puts "\tUsername: ".colorize(:cyan) + config.username
+            Formatter.colorize "\tURL", uri.to_s
+            Formatter.colorize "\tOrganization", config.organization
+            Formatter.colorize "\tUsername", config.username
           rescue StandardError => ex
             $stderr.puts "Failed to load config file #{fname}: #{ex}"
           end

--- a/lib/cyclid/cli/organization/config.rb
+++ b/lib/cyclid/cli/organization/config.rb
@@ -30,32 +30,32 @@ module Cyclid
           case type
           when 'string', 'integer'
             data = config[name] || 'Not set'
-            puts "#{setting['description']}: ".colorize(:cyan) + data
+            Formatter.colorize setting['description'], data
           when 'password'
             data = config[name] ? '*' * config[name].length : 'Not set'
-            puts "#{setting['description']}: ".colorize(:cyan) + data
+            Formatter.colorize setting['description'], data
           when 'boolean'
             data = config[name] || 'Not set'
-            puts "#{setting['description']}: ".colorize(:cyan) + (data ? 'true' : 'false')
+            Formatter.colorize setting['description'], (data ? 'true' : 'false')
           when 'list'
-            puts setting['description'].colorize(:cyan)
+            Formatter.colorize setting['description']
             data = config[name]
             if data.empty?
-              puts "\tNone"
+              Formatter.puts "\tNone"
             else
               data.each do |item|
-                puts "\t#{item}"
+                Formatter.puts "\t#{item}"
               end
             end
           when 'hash-list'
-            puts setting['description'].colorize(:cyan)
+            Formatter.colorize setting['description']
             data = config[name]
             if data.empty?
-              puts "\tNone"
+              Formatter.puts "\tNone"
             else
               data.each do |item|
                 item.each do |k, v|
-                  puts "\t#{k}: #{v}"
+                  Formatter.puts "\t#{k}: #{v}"
                 end
               end
             end

--- a/lib/cyclid/cli/organization/member.rb
+++ b/lib/cyclid/cli/organization/member.rb
@@ -82,11 +82,11 @@ module Cyclid
         user = client.org_user_get(client.config.organization, user)
 
         # Pretty print the user details
-        puts 'Username: '.colorize(:cyan) + user['username']
-        puts 'Email: '.colorize(:cyan) + user['email']
-        puts 'Permissions'.colorize(:cyan)
+        Formatter.colorize 'Username', user['username']
+        Formatter.colorize 'Email: ', user['email']
+        Formatter.colorize 'Permissions'
         user['permissions'].each do |k, v|
-          puts "\t#{k.capitalize}: ".colorize(:cyan) + v.to_s
+          Formatter.colorize "\t#{k.capitalize}", v.to_s
         end
       rescue StandardError => ex
         abort "Failed to get user: #{ex}"
@@ -110,7 +110,7 @@ module Cyclid
             if options[:force]
               true
             else
-              print "Remove user #{user}: are you sure? (Y/n): ".colorize(:red)
+              Formatter.ask "Remove user #{user}: are you sure? (Y/n)"
               STDIN.getc.chr.casecmp('y').zero?
             end
           end

--- a/lib/cyclid/cli/secret.rb
+++ b/lib/cyclid/cli/secret.rb
@@ -34,7 +34,7 @@ module Cyclid
         # Encrypt with the public key
         encrypted = public_key.public_encrypt(secret)
 
-        puts 'Secret: '.colorize(:cyan) + Base64.strict_encode64(encrypted)
+        Formatter.colorize 'Secret', Base64.strict_encode64(encrypted)
       rescue StandardError => ex
         abort "Failed to encrypt secret: #{ex}"
       end

--- a/lib/cyclid/cli/stage.rb
+++ b/lib/cyclid/cli/stage.rb
@@ -21,7 +21,7 @@ module Cyclid
       def list
         stages = client.stage_list(client.config.organization)
         stages.each do |stage|
-          puts "#{stage[:name]} v#{stage[:version]}"
+          Formatter.puts "#{stage[:name]} v#{stage[:version]}"
         end
       rescue StandardError => ex
         abort "Failed to get stages: #{ex}"
@@ -33,14 +33,14 @@ module Cyclid
 
         # Pretty print the stage details
         stages.each do |stage|
-          puts 'Name: '.colorize(:cyan) + stage['name']
-          puts 'Version: '.colorize(:cyan) + stage['version']
-          puts 'Steps'.colorize(:cyan)
+          Formatter.colorize 'Name', stage['name']
+          Formatter.colorize 'Version', stage['version']
+          Formatter.colorize 'Steps'
           stage['steps'].each do |step|
-            puts "\t\tAction: ".colorize(:cyan) + step['action']
+            Formatter.colorize"\t\tAction", step['action']
             step.delete('action')
             step.each do |k, v|
-              puts "\t\t#{k.capitalize}: ".colorize(:cyan) + v.to_s
+              Formatter.colorize "\t\t#{k.capitalize}: ", v.to_s
             end
           end
         end

--- a/lib/cyclid/cli/user.rb
+++ b/lib/cyclid/cli/user.rb
@@ -25,16 +25,16 @@ module Cyclid
         user = client.user_get(client.config.username)
 
         # Pretty print the user details
-        puts 'Username: '.colorize(:cyan) + user['username']
-        puts 'Name: '.colorize(:cyan) + (user['name'] || '')
-        puts 'Email: '.colorize(:cyan) + user['email']
-        puts 'Organizations'.colorize(:cyan)
+        Formatter.colorize 'Username', user['username']
+        Formatter.colorize 'Name', (user['name'] || '')
+        Formatter.colorize 'Email', user['email']
+        Formatter.colorize 'Organizations'
         if user['organizations'].any?
           user['organizations'].each do |org|
-            puts "\t#{org}"
+            Formatter.puts "\t#{org}"
           end
         else
-          puts "\tNone"
+          Formatter.puts "\tNone"
         end
       rescue StandardError => ex
         abort "Failed to get user: #{ex}"
@@ -109,7 +109,7 @@ module Cyclid
         puts
 
         # Create a client that can authenticate with HTTP BASIC
-        puts "Authenticating #{username} with #{url}".colorize(:cyan)
+        Formatter.colorize "Authenticating #{username} with #{url}"
 
         basic_client = Cyclid::Client::Tilapia.new(auth: Cyclid::Client::AuthMethods::AUTH_BASIC,
                                                    url: url,
@@ -125,7 +125,7 @@ module Cyclid
 
         # Generate a configuration file for each organization
         user['organizations'].each do |org|
-          puts "Creating configuration file for organization #{org}".colorize(:cyan)
+          Formatter.colorize "Creating configuration file for organization #{org}"
 
           org_config = File.new(File.join(CYCLID_CONFIG_DIR, org), 'w+', 0o600)
           org_config.write "url: #{url}\n"

--- a/lib/cyclid/client.rb
+++ b/lib/cyclid/client.rb
@@ -87,8 +87,8 @@ module Cyclid
         scheme = @config.tls ? URI::HTTPS : URI::HTTP
         scheme.build(host: @config.server,
                      port: @config.port,
-                     path: path,
-                     query: query)
+                     path: URI.escape(path),
+                     query: query ? URI.escape(query) : nil)
       end
 
       def method_missing(method, *args, &block) # rubocop:disable Style/MethodMissing

--- a/spec/cli/organization_spec.rb
+++ b/spec/cli/organization_spec.rb
@@ -30,7 +30,7 @@ describe Cyclid::Cli::Organization do
         expect{ subject.show }.to output(/Name:.*test/).to_stdout
         expect{ subject.show }.to output(/Owner Email:.*test@example.com/).to_stdout
         expect{ subject.show }.to output(/Public Key:.*-----BEGIN PUBLIC KEY-----/).to_stdout
-        expect{ subject.show }.to output(/Members:.*\n\s*None/).to_stdout
+        expect{ subject.show }.to output(/Members.*\n\s*None/).to_stdout
       end
 
       it 'shows an organization with members' do
@@ -54,7 +54,7 @@ describe Cyclid::Cli::Organization do
         expect{ subject.show }.to output(/Name:.*test/).to_stdout
         expect{ subject.show }.to output(/Owner Email:.*test@example.com/).to_stdout
         expect{ subject.show }.to output(/Public Key:.*-----BEGIN PUBLIC KEY-----/).to_stdout
-        expect{ subject.show }.to output(/Members:.*\n\s*bob.*\n\s*leslie/).to_stdout
+        expect{ subject.show }.to output(/Members.*\n\s*bob.*\n\s*leslie/).to_stdout
       end
 
       it 'fails gracefully when the server returns a non-200 response' do


### PR DESCRIPTION
Escape paths & query strings used to build API requests.
Add the Formatter module that can choose to output colorized strings on the terminal but plain, unformatted strings elsewhere I.e. when the output is piped.
Use the Formatter methods instead of directly calling puts/print with colorize everywhere.