### PR TITLE
Adds helper text when org not setup

### DIFF
--- a/lib/cyclid/config.rb
+++ b/lib/cyclid/config.rb
@@ -65,6 +65,9 @@ module Cyclid
       def initialize(options = {})
         # Load the config if a path was provided
         @path = options[:path] || nil
+        unless File.file?(@path)
+          raise "no config found at #{@path} - Have you selected an organisation with `cyclid organization use <name>`?"
+        end
         @config = @path.nil? ? nil : YAML.load_file(@path)
 
         # Select the authentication type & associated authentication data.

--- a/spec/client/health_spec.rb
+++ b/spec/client/health_spec.rb
@@ -13,6 +13,10 @@ describe Cyclid::Client::Health do
       Cyclid::Client::Tilapia.new(config)
     end
 
+    before :each do
+      allow(File).to receive(:file?).and_return(true)
+    end
+
     it 'retrieves the health status when the server is healthy' do
       stub_request(:get, 'http://example.com:9999/health/status')
         .with(headers: { 'Accept' => '*/*',

--- a/spec/client/job_spec.rb
+++ b/spec/client/job_spec.rb
@@ -2,6 +2,14 @@
 require 'client_helper'
 
 describe Cyclid::Client::Job do
+  context 'when no organization configured' do
+    it 'returns helper message instead of raw error' do
+      non_existant_path = File.join('/tmp/foo/', '.cyclid', 'config')
+      error_message = "no config found at /tmp/foo/.cyclid/config - Have you selected an organisation with `cyclid organization use <name>`?"
+      expect{ @client = Cyclid::Client::Tilapia.new(path: non_existant_path) }.to raise_error(error_message)
+    end
+  end
+
   context 'retrieving job information' do
     before :all do
       @client = Cyclid::Client::Tilapia.new(path: ENV['TEST_CONFIG'])


### PR DESCRIPTION
* before `Failed to get job list: No such file or directory @ rb_sysopen - /Users/petersouter/.cyclid/config`
* after `Failed to get job list: no config found at /Users/petersouter/.cyclid/config - Have you selected an organisation with `cyclid organization use <name>`?`